### PR TITLE
require a % of AI to be killed for mission to complete

### DIFF
--- a/DZMS/DZMSConfig.sqf
+++ b/DZMS/DZMSConfig.sqf
@@ -31,6 +31,9 @@ DZMSRunGear = false;
 // How long before bodies disappear? (in seconds) (default = 2400)
 DZMSBodyTime = 2400;
 
+// Percentage of AI that must be dead before mission completes (default = 0)
+DZMSRequiredKillPercent = 0;
+
 //////////////////////////////////////////////////////////////////////////////////////////
 // You can adjust the weapons that spawn in weapon crates inside DZMSWeaponCrateList.sqf
 // You can adjust the AI's gear inside DZMSAIConfig.sqf in the ExtConfig folder also.

--- a/DZMS/DZMSFunctions.sqf
+++ b/DZMS/DZMSFunctions.sqf
@@ -3,6 +3,7 @@
 	by Vampire
 */
 
+diag_log "[DZMS]: loading execVM sqf scripts.";
 DZMSMajTimer = "\z\addons\dayz_server\DZMS\Scripts\DZMSMajTimer.sqf";
 DZMSMinTimer = "\z\addons\dayz_server\DZMS\Scripts\DZMSMinTimer.sqf";
 DZMSMarkerLoop = "\z\addons\dayz_server\DZMS\Scripts\DZMSMarkerLoop.sqf";
@@ -10,12 +11,16 @@ DZMSMarkerLoop = "\z\addons\dayz_server\DZMS\Scripts\DZMSMarkerLoop.sqf";
 DZMSAddMajMarker = "\z\addons\dayz_server\DZMS\Scripts\DZMSAddMajMarker.sqf";
 DZMSAddMinMarker = "\z\addons\dayz_server\DZMS\Scripts\DZMSAddMinMarker.sqf";
 
-DZMSAISpawn = "\z\addons\dayz_server\DZMS\Scripts\DZMSAISpawn.sqf";
 DZMSAIKilled = "\z\addons\dayz_server\DZMS\Scripts\DZMSAIKilled.sqf";
 
 DZMSBoxSetup = "\z\addons\dayz_server\DZMS\Scripts\DZMSBox.sqf";
 DZMSSaveVeh = "\z\addons\dayz_server\DZMS\Scripts\DZMSSaveToHive.sqf";
 
+diag_log "[DZMS]: loading compiled functions.";
+// compiled functions
+DZMSAISpawn = compile preprocessFileLineNumbers "\z\addons\dayz_server\DZMS\Scripts\DZMSAISpawn.sqf";
+
+diag_log "[DZMS]: loading all other functions.";
 //Attempts to find a mission location
 //If findSafePos fails it searches again until a position is found
 //This fixes the issue with missions spawning in Novy Sobor on Chernarus
@@ -198,6 +203,15 @@ DZMSGetWeapon = {
 	_fin
 };
 
+DZMSWaitMissionComp = {
+    private["_objective","_unitArrayName","_numSpawned","_numKillReq"];
+    _objective = _this select 0;
+    _unitArrayName = _this select 1;
+    call compile format["_numSpawned = count %1;",_unitArrayName];
+    _numKillReq = ceil(DZMSRequiredKillPercent * _numSpawned);
+    diag_log format["[DZMS]: (%3) waiting for %1/%2 units or less to be alive and a player to be near objective.",(_numSpawned - _numKillReq),_numSpawned,_unitArrayName];
+    call compile format["waitUntil{sleep 1; ({isPlayer _x && _x distance _objective <= 30} count playableUnits > 0) && ({alive _x} count %1 <= (_numSpawned - _numKillReq));};",_unitArrayName];
+};
 
 //------------------------------------------------------------------//
 diag_log format ["[DZMS]: Mission Functions Script Loaded!"];

--- a/DZMS/DZMSInit.sqf
+++ b/DZMS/DZMSInit.sqf
@@ -97,6 +97,10 @@ if (DZMSEpoch) then {
 // Lets load our functions
 call compile preprocessFileLineNumbers "\z\addons\dayz_server\DZMS\DZMSFunctions.sqf";
 
+// these arrays are used to hold units for each mission type
+DZMSUnitsMinor = [];
+DZMSUnitsMajor = [];
+
 // Let's get the clocks running!
 [] ExecVM DZMSMajTimer;
 [] ExecVM DZMSMinTimer;

--- a/DZMS/Missions/Major/EM1.sqf
+++ b/DZMS/Missions/Major/EM1.sqf
@@ -82,16 +82,16 @@ _crate1 = createVehicle ["USLaunchersBox",[(_coords select 0) + 0.3428,(_coords 
 
 //DZMSAISpawn spawns AI to the mission.
 //Usage: [_coords, count, skillLevel]
-[[(_coords select 0) - 10.5005,(_coords select 1) - 2.6465,0],6,1,1] ExecVM DZMSAISpawn;
+[[(_coords select 0) - 10.5005,(_coords select 1) - 2.6465,0],6,1,"DZMSUnitsMajor"] call DZMSAISpawn;
 sleep 5;
-[[(_coords select 0) + 4.7027,(_coords select 1) + 12.2138,0],6,1,1] ExecVM DZMSAISpawn;
+[[(_coords select 0) + 4.7027,(_coords select 1) + 12.2138,0],6,1,"DZMSUnitsMajor"] call DZMSAISpawn;
 sleep 5;
-[[(_coords select 0) + 2.918,(_coords select 1) - 9.0342,0],4,1,1] ExecVM DZMSAISpawn;
+[[(_coords select 0) + 2.918,(_coords select 1) - 9.0342,0],4,1,"DZMSUnitsMajor"] call DZMSAISpawn;
 sleep 5;
-[[(_coords select 0) + 2.918,(_coords select 1) - 9.0342,0],4,1,1] ExecVM DZMSAISpawn;
+[[(_coords select 0) + 2.918,(_coords select 1) - 9.0342,0],4,1,"DZMSUnitsMajor"] call DZMSAISpawn;
 
-//Wait until the player is within 30meters
-waitUntil{{isPlayer _x && _x distance _coords <= 30 } count playableunits > 0}; 
+//Wait until the player is within 30 meters and also meets the kill req
+[_coords,"DZMSUnitsMajor"] call DZMSWaitMissionComp;
 
 //Call DZMSSaveVeh to attempt to save the vehicles to the database
 //If saving is off, the script will exit.

--- a/DZMS/Missions/Major/SM1.sqf
+++ b/DZMS/Missions/Major/SM1.sqf
@@ -42,17 +42,17 @@ _crate3 = createVehicle ["AmmoBoxSmall_556",[(_coords select 0) + 4.0996,(_coord
 
 //DZMSAISpawn spawns AI to the mission.
 //Usage: [_coords, count, skillLevel]
-[[(_coords select 0) + 0.0352,(_coords select 1) - 6.8799, 0],6,1,1] ExecVM DZMSAISpawn;
+[[(_coords select 0) + 0.0352,(_coords select 1) - 6.8799, 0],6,1,"DZMSUnitsMajor"] call DZMSAISpawn;
 sleep 5;
-[[(_coords select 0) + 0.0352,(_coords select 1) - 6.8799, 0],6,1,1] ExecVM DZMSAISpawn;
+[[(_coords select 0) + 0.0352,(_coords select 1) - 6.8799, 0],6,1,"DZMSUnitsMajor"] call DZMSAISpawn;
 sleep 5;
-[[(_coords select 0) + 0.0352,(_coords select 1) - 6.8799, 0],4,1,1] ExecVM DZMSAISpawn;
+[[(_coords select 0) + 0.0352,(_coords select 1) - 6.8799, 0],4,1,"DZMSUnitsMajor"] call DZMSAISpawn;
 sleep 5;
-[[(_coords select 0) + 0.0352,(_coords select 1) - 6.8799, 0],4,1,1] ExecVM DZMSAISpawn;
+[[(_coords select 0) + 0.0352,(_coords select 1) - 6.8799, 0],4,1,"DZMSUnitsMajor"] call DZMSAISpawn;
 sleep 5;
 
-//Wait until the player is within 30meters
-waitUntil{ {isPlayer _x && _x distance _coords <= 30 } count playableunits > 0 }; 
+//Wait until the player is within 30 meters and also meets the kill req
+[_coords,"DZMSUnitsMajor"] call DZMSWaitMissionComp;
 
 //Call DZMSSaveVeh to attempt to save the vehicles to the database
 //If saving is off, the script will exit.

--- a/DZMS/Missions/Major/SM2.sqf
+++ b/DZMS/Missions/Major/SM2.sqf
@@ -48,11 +48,11 @@ sleep 5;
 
 //DZMSAISpawn spawns AI to the mission.
 //Usage: [_coords, count, skillLevel]
-[_coords,6,1,1] ExecVM DZMSAISpawn;
+[_coords,6,1,"DZMSUnitsMajor"] call DZMSAISpawn;
 sleep 5;
-[_coords,6,1,1] ExecVM DZMSAISpawn;
+[_coords,6,1,"DZMSUnitsMajor"] call DZMSAISpawn;
 sleep 5;
-[_coords,4,1,1] ExecVM DZMSAISpawn;
+[_coords,4,1,"DZMSUnitsMajor"] call DZMSAISpawn;
 sleep 5;
 
 _loop = true;
@@ -150,8 +150,8 @@ clearBackpackCargoGlobal _boxFin;
 [_boxFin,"weapons"] ExecVM DZMSBoxSetup;
 [_boxFin] call DZMSProtectObj;
 
-//Wait until the player is within 30meters
-waitUntil{{isPlayer _x && _x distance _boxFin <= 30 } count playableunits > 0}; 
+//Wait until the player is within 30 meters and also meets the kill req
+[_boxFin,"DZMSUnitsMajor"] call DZMSWaitMissionComp;
 
 //Let everyone know the mission is over
 [nil,nil,rTitleText,"The AN2 Cargo has been Secured by Survivors!", "PLAIN",6] call RE;

--- a/DZMS/Missions/Major/SM3.sqf
+++ b/DZMS/Missions/Major/SM3.sqf
@@ -101,16 +101,17 @@ _crate = createVehicle ["USLaunchersBox",[(_coords select 0) - 6.8277, (_coords 
 
 //DZMSAISpawn spawns AI to the mission.
 //Usage: [_coords, count, skillLevel]
-[[(_coords select 0) - 0.5635,(_coords select 1) + 0.3173,0],3,1,1] ExecVM DZMSAISpawn;
+[[(_coords select 0) - 0.5635,(_coords select 1) + 0.3173,0],3,1,"DZMSUnitsMajor"] call DZMSAISpawn;
 sleep 5;
-[[(_coords select 0) - 0.5635,(_coords select 1) + 0.3173,0],3,1,1] ExecVM DZMSAISpawn;
+[[(_coords select 0) - 0.5635,(_coords select 1) + 0.3173,0],3,1,"DZMSUnitsMajor"] call DZMSAISpawn;
 sleep 5;
-[[(_coords select 0) - 0.5635,(_coords select 1) + 0.3173,0],3,1,1] ExecVM DZMSAISpawn;
+[[(_coords select 0) - 0.5635,(_coords select 1) + 0.3173,0],3,1,"DZMSUnitsMajor"] call DZMSAISpawn;
 sleep 5;
-[[(_coords select 0) - 0.5635,(_coords select 1) + 0.3173,0],3,1,1] ExecVM DZMSAISpawn;
+[[(_coords select 0) - 0.5635,(_coords select 1) + 0.3173,0],3,1,"DZMSUnitsMajor"] call DZMSAISpawn;
 
-//Wait until the player is within 30meters
-waitUntil{{isPlayer _x && _x distance _coords <= 30  } count playableunits > 0};
+
+//Wait until the player is within 30 meters and also meets the kill req
+[_coords,"DZMSUnitsMajor"] call DZMSWaitMissionComp;
 
 //Call DZMSSaveVeh to attempt to save the vehicles to the database
 //If saving is off, the script will exit.

--- a/DZMS/Missions/Major/SM4.sqf
+++ b/DZMS/Missions/Major/SM4.sqf
@@ -44,17 +44,17 @@ _crate2 = createVehicle ["USLaunchersBox",[(_coords select 0) - 7.1718,(_coords 
 
 //DZMSAISpawn spawns AI to the mission.
 //Usage: [_coords, count, skillLevel]
-[[(_coords select 0) - 8.4614,(_coords select 1) - 5.0527,0],6,1,1] ExecVM DZMSAISpawn;
+[[(_coords select 0) - 8.4614,(_coords select 1) - 5.0527,0],6,1,"DZMSUnitsMajor"] call DZMSAISpawn;
 sleep 5;
-[[(_coords select 0) - 8.4614,(_coords select 1) - 5.0527,0],4,1,1] ExecVM DZMSAISpawn;
+[[(_coords select 0) - 8.4614,(_coords select 1) - 5.0527,0],4,1,"DZMSUnitsMajor"] call DZMSAISpawn;
 sleep 5;
-[[(_coords select 0) + 7.5337,(_coords select 1) + 4.2656,0],4,1,1] ExecVM DZMSAISpawn;
+[[(_coords select 0) + 7.5337,(_coords select 1) + 4.2656,0],4,1,"DZMSUnitsMajor"] call DZMSAISpawn;
 sleep 5;
-[[(_coords select 0) + 7.5337,(_coords select 1) + 4.2656,0],4,1,1] ExecVM DZMSAISpawn;
+[[(_coords select 0) + 7.5337,(_coords select 1) + 4.2656,0],4,1,"DZMSUnitsMajor"] call DZMSAISpawn;
 sleep 5;
 
-//Wait until the player is within 30meters
-waitUntil{{isPlayer _x && _x distance _coords <= 30  } count playableunits > 0}; 
+//Wait until the player is within 30 meters and also meets the kill req
+[_coords,"DZMSUnitsMajor"] call DZMSWaitMissionComp;
 
 //Call DZMSSaveVeh to attempt to save the vehicles to the database
 //If saving is off, the script will exit.

--- a/DZMS/Missions/Major/SM5.sqf
+++ b/DZMS/Missions/Major/SM5.sqf
@@ -59,14 +59,15 @@ _crate3 = createVehicle ["USBasicAmmunitionBox",[(_coords select 0) + 2.5405,(_c
 [_crate3] call DZMSProtectObj;
 _crate3 setDir -27.93351;
 
-[[(_coords select 0) - 6.9458,(_coords select 1) - 3.5352, 0],6,1,1] ExecVM DZMSAISpawn;
+[[(_coords select 0) - 6.9458,(_coords select 1) - 3.5352, 0],6,1,"DZMSUnitsMajor"] call DZMSAISpawn;
 sleep 5;
-[[(_coords select 0) + 4.4614,(_coords select 1) + 2.5898, 0],6,1,1] ExecVM DZMSAISpawn;
+[[(_coords select 0) + 4.4614,(_coords select 1) + 2.5898, 0],6,1,"DZMSUnitsMajor"] call DZMSAISpawn;
 sleep 5;
-[[(_coords select 0) + 4.4614,(_coords select 1) + 2.5898, 0],4,1,1] ExecVM DZMSAISpawn;
+[[(_coords select 0) + 4.4614,(_coords select 1) + 2.5898, 0],4,1,"DZMSUnitsMajor"] call DZMSAISpawn;
 sleep 5;
 
-waitUntil{{isPlayer _x && _x distance _coords <= 30  } count playableunits > 0}; 
+//Wait until the player is within 30 meters and also meets the kill req
+[_coords,"DZMSUnitsMajor"] call DZMSWaitMissionComp;
 
 //Call DZMSSaveVeh to attempt to save the vehicles to the database
 //If saving is off, the script will exit.

--- a/DZMS/Missions/Major/SM6.sqf
+++ b/DZMS/Missions/Major/SM6.sqf
@@ -42,17 +42,17 @@ _crate3 = createVehicle ["MedBox0",[(_coords select 0) + 4.0996,(_coords select 
 
 //DZMSAISpawn spawns AI to the mission.
 //Usage: [_coords, count, skillLevel]
-[[(_coords select 0) + 0.0352,(_coords select 1) - 6.8799, 0],6,1,1] ExecVM DZMSAISpawn;
+[[(_coords select 0) + 0.0352,(_coords select 1) - 6.8799, 0],6,1,"DZMSUnitsMajor"] call DZMSAISpawn;
 sleep 5;
-[[(_coords select 0) + 0.0352,(_coords select 1) - 6.8799, 0],6,1,1] ExecVM DZMSAISpawn;
+[[(_coords select 0) + 0.0352,(_coords select 1) - 6.8799, 0],6,1,"DZMSUnitsMajor"] call DZMSAISpawn;
 sleep 5;
-[[(_coords select 0) + 0.0352,(_coords select 1) - 6.8799, 0],4,1,1] ExecVM DZMSAISpawn;
+[[(_coords select 0) + 0.0352,(_coords select 1) - 6.8799, 0],4,1,"DZMSUnitsMajor"] call DZMSAISpawn;
 sleep 5;
-[[(_coords select 0) + 0.0352,(_coords select 1) - 6.8799, 0],4,1,1] ExecVM DZMSAISpawn;
+[[(_coords select 0) + 0.0352,(_coords select 1) - 6.8799, 0],4,1,"DZMSUnitsMajor"] call DZMSAISpawn;
 sleep 5;
 
-//Wait until the player is within 30meters
-waitUntil{ {isPlayer _x && _x distance _coords <= 30 } count playableunits > 0 }; 
+//Wait until the player is within 30 meters and also meets the kill req
+[_coords,"DZMSUnitsMajor"] call DZMSWaitMissionComp;
 
 //Call DZMSSaveVeh to attempt to save the vehicles to the database
 //If saving is off, the script will exit.

--- a/DZMS/Missions/Minor/SM1.sqf
+++ b/DZMS/Missions/Minor/SM1.sqf
@@ -21,16 +21,17 @@ _vehicle = createVehicle ["UAZ_Unarmed_UN_EP1",[(_coords select 0) + 10, (_coord
 //DZMSSetupVehicle prevents the vehicle from disappearing and sets fuel and such
 [_vehicle] call DZMSSetupVehicle;
 
-[_coords,2,1,0] ExecVM DZMSAISpawn;
+[_coords,2,1,"DZMSUnitsMinor"] call DZMSAISpawn;
 sleep 5;
-[_coords,2,1,0] ExecVM DZMSAISpawn;
+[_coords,2,1,"DZMSUnitsMinor"] call DZMSAISpawn;
 sleep 5;
-[_coords,2,1,0] ExecVM DZMSAISpawn;
+[_coords,2,1,"DZMSUnitsMinor"] call DZMSAISpawn;
 sleep 5;
-[_coords,2,1,0] ExecVM DZMSAISpawn;
+[_coords,2,1,"DZMSUnitsMinor"] call DZMSAISpawn;
 sleep 1;
 
-waitUntil{ {isPlayer _x && _x distance _coords <= 30 } count playableunits > 0 };
+//Wait until the player is within 30 meters and also meets the kill req
+[_coords,"DZMSUnitsMinor"] call DZMSWaitMissionComp;
 
 //Call DZMSSaveVeh to attempt to save the vehicles to the database
 //If saving is off, the script will exit.

--- a/DZMS/Missions/Minor/SM2.sqf
+++ b/DZMS/Missions/Minor/SM2.sqf
@@ -48,17 +48,17 @@ _crate2 = createVehicle ["USLaunchersBox",[(_coords select 0) - 8, _coords selec
 
 //DZMSAISpawn spawns AI to the mission.
 //Usage: [_coords, count, skillLevel]
-[[(_coords select 0) - 20, (_coords select 1) - 15,0],4,0,0] ExecVM DZMSAISpawn;
+[[(_coords select 0) - 20, (_coords select 1) - 15,0],4,0,"DZMSUnitsMinor"] call DZMSAISpawn;
 sleep 3;
-[[(_coords select 0) + 10, (_coords select 1) + 15,0],4,0,0] ExecVM DZMSAISpawn;
+[[(_coords select 0) + 10, (_coords select 1) + 15,0],4,0,"DZMSUnitsMinor"] call DZMSAISpawn;
 sleep 3;
-[[(_coords select 0) - 10, (_coords select 1) - 15,0],4,0,0] ExecVM DZMSAISpawn;
+[[(_coords select 0) - 10, (_coords select 1) - 15,0],4,0,"DZMSUnitsMinor"] call DZMSAISpawn;
 sleep 3;
-[[(_coords select 0) + 20, (_coords select 1) + 15,0],4,0,0] ExecVM DZMSAISpawn;
+[[(_coords select 0) + 20, (_coords select 1) + 15,0],4,0,"DZMSUnitsMinor"] call DZMSAISpawn;
 sleep 3;
 
-//Wait until the player is within 30meters
-waitUntil{{isPlayer _x && _x distance _coords <= 30  } count playableunits > 0}; 
+//Wait until the player is within 30 meters and also meets the kill req
+[_coords,"DZMSUnitsMinor"] call DZMSWaitMissionComp;
 
 //Call DZMSSaveVeh to attempt to save the vehicles to the database
 //If saving is off, the script will exit.

--- a/DZMS/Missions/Minor/SM3.sqf
+++ b/DZMS/Missions/Minor/SM3.sqf
@@ -40,13 +40,13 @@ _crate = createVehicle ["USVehicleBox",[(_coords select 0) - 3, _coords select 1
 
 //DZMSAISpawn spawns AI to the mission.
 //Usage: [_coords, count, skillLevel]
-[[(_coords select 0) - 20, (_coords select 1) - 15,0],6,0,0] ExecVM DZMSAISpawn;
+[[(_coords select 0) - 20, (_coords select 1) - 15,0],6,0,"DZMSUnitsMinor"] call DZMSAISpawn;
 sleep 3;
-[[(_coords select 0) + 20, (_coords select 1) + 15,0],6,0,0] ExecVM DZMSAISpawn;
+[[(_coords select 0) + 20, (_coords select 1) + 15,0],6,0,"DZMSUnitsMinor"] call DZMSAISpawn;
 sleep 3;
 
-//Wait until the player is within 30meters
-waitUntil{{isPlayer _x && _x distance _coords <= 30  } count playableunits > 0}; 
+//Wait until the player is within 30 meters and also meets the kill req
+[_coords,"DZMSUnitsMinor"] call DZMSWaitMissionComp;
 
 //Call DZMSSaveVeh to attempt to save the vehicles to the database
 //If saving is off, the script will exit.

--- a/DZMS/Missions/Minor/SM4.sqf
+++ b/DZMS/Missions/Minor/SM4.sqf
@@ -28,15 +28,15 @@ _crate = createVehicle ["USLaunchersBox",[(_coords select 0) - 6, _coords select
 
 //DZMSAISpawn spawns AI to the mission.
 //Usage: [_coords, count, skillLevel]
-[_coords,3,1,0] ExecVM DZMSAISpawn;
+[_coords,3,1,"DZMSUnitsMinor"] call DZMSAISpawn;
 sleep 1;
-[_coords,3,1,0] ExecVM DZMSAISpawn;
+[_coords,3,1,"DZMSUnitsMinor"] call DZMSAISpawn;
 sleep 1;
-[_coords,3,1,0] ExecVM DZMSAISpawn;
+[_coords,3,1,"DZMSUnitsMinor"] call DZMSAISpawn;
 sleep 1;
 
-//Wait until the player is within 30meters
-waitUntil{{isPlayer _x && _x distance _coords <= 30  } count playableunits > 0}; 
+//Wait until the player is within 30 meters and also meets the kill req
+[_coords,"DZMSUnitsMinor"] call DZMSWaitMissionComp;
 
 //Let everyone know the mission is over
 [nil,nil,rTitleText,"The crash site has been secured by survivors!", "PLAIN",6] call RE;

--- a/DZMS/Missions/Minor/SM5.sqf
+++ b/DZMS/Missions/Minor/SM5.sqf
@@ -28,13 +28,13 @@ _crate = createVehicle ["RULaunchersBox",[(_coords select 0) - 14, _coords selec
 
 //DZMSAISpawn spawns AI to the mission.
 //Usage: [_coords, count, skillLevel]
-[_coords,3,1,0] ExecVM DZMSAISpawn;
+[_coords,3,1,"DZMSUnitsMinor"] call DZMSAISpawn;
 sleep 1;
-[_coords,3,1,0] ExecVM DZMSAISpawn;
+[_coords,3,1,"DZMSUnitsMinor"] call DZMSAISpawn;
 sleep 1;
 
-//Wait until the player is within 30meters
-waitUntil{{isPlayer _x && _x distance _coords <= 30 } count playableunits > 0}; 
+//Wait until the player is within 30 meters and also meets the kill req
+[_coords,"DZMSUnitsMinor"] call DZMSWaitMissionComp;
 
 //Let everyone know the mission is over
 [nil,nil,rTitleText,"The crash site has been secured by survivors!", "PLAIN",6] call RE;

--- a/DZMS/Missions/Minor/SM6.sqf
+++ b/DZMS/Missions/Minor/SM6.sqf
@@ -36,17 +36,17 @@ _crate2 = createVehicle ["RULaunchersBox",[(_coords select 0) - 6, _coords selec
 
 //DZMSAISpawn spawns AI to the mission.
 //Usage: [_coords, count, skillLevel]
-[_coords,3,0,0] ExecVM DZMSAISpawn;
+[_coords,3,0,"DZMSUnitsMinor"] call DZMSAISpawn;
 sleep 1;
-[_coords,3,0,0] ExecVM DZMSAISpawn;
+[_coords,3,0,"DZMSUnitsMinor"] call DZMSAISpawn;
 sleep 1;
-[_coords,3,0,0] ExecVM DZMSAISpawn;
+[_coords,3,0,"DZMSUnitsMinor"] call DZMSAISpawn;
 sleep 1;
-[_coords,3,0,0] ExecVM DZMSAISpawn;
+[_coords,3,0,"DZMSUnitsMinor"] call DZMSAISpawn;
 sleep 1;
 
-//Wait until the player is within 30meters
-waitUntil{{isPlayer _x && _x distance _coords <= 30 } count playableunits > 0}; 
+//Wait until the player is within 30 meters and also meets the kill req
+[_coords,"DZMSUnitsMinor"] call DZMSWaitMissionComp;
 
 //Let everyone know the mission is over
 [nil,nil,rTitleText,"The crash site has been secured by survivors!", "PLAIN",6] call RE;

--- a/DZMS/Scripts/DZMSAISpawn.sqf
+++ b/DZMS/Scripts/DZMSAISpawn.sqf
@@ -5,11 +5,11 @@
 		UnitCount is the number of units to spawn
 		SkillLevel is the skill number defined in DZMSAIConfig.sqf
 */																		//
-private ["_position","_unitcount","_skill","_wpRadius","_xpos","_ypos","_unitGroup","_aiskin","_unit","_weapon","_magazine","_wppos1","_wppos2","_wppos3","_wppos4","_wp1","_wp2","_wp3","_wp4","_wpfin","_missionType"];
+private ["_position","_unitcount","_skill","_wpRadius","_xpos","_ypos","_unitGroup","_aiskin","_unit","_weapon","_magazine","_wppos1","_wppos2","_wppos3","_wppos4","_wp1","_wp2","_wp3","_wp4","_wpfin","_unitArrayName","_unitMissionCount"];
 _position = _this select 0;
 _unitcount = _this select 1;
 _skill = _this select 2;
-_missionType = _this select 3;
+_unitArrayName = _this select 3;
 
 //diag_log format ["[DZMS]: AI Pos:%1 / AI UnitNum: %2 / AI SkillLev:%3",_position,_unitcount,_skill];
 
@@ -134,8 +134,9 @@ _wpfin setWaypointType "CYCLE";
 
 //diag_log format ["[DZMS]: Spawned %1 AI at %2",_unitcount,_position];
 
-// load the unit groups into an array based upon their mission type so they can be cleaned up later
-switch(_missionType) do {
-    case 0: {DZMS_UNITS_MINOR = DZMS_UNITS_MINOR + (units _unitGroup);};
-    case 1: {DZMS_UNITS_MAJOR = DZMS_UNITS_MAJOR + (units _unitGroup);};
-};
+// load the unit groups into a passed array name so they can be cleaned up later
+call compile format["
+%1 = %1 + (units _unitGroup); 
+_unitMissionCount = count %1;
+",_unitArrayName];
+diag_log format["[DZMS]: (%3) %1 AI Spawned, %2 units in mission.",count (units _unitGroup),_unitMissionCount,_unitArrayName];

--- a/DZMS/Scripts/DZMSMajTimer.sqf
+++ b/DZMS/Scripts/DZMSMajTimer.sqf
@@ -28,9 +28,6 @@ while {_run} do
 	//Lets pick a mission
 	_ranMis = floor (random _cntMis);
 	_varName = DZMSMajorArray select _ranMis;
-	
-    // create array of units if it doesn't exist
-    if (isNil "DZMS_UNITS_MAJOR") then { DZMS_UNITS_MAJOR = []; };
     
     // clean up all the existing units before starting a new one
     {
@@ -49,10 +46,10 @@ while {_run} do
         deleteVehicle _x;
         deleteGroup (group _x);
         _x = nil;
-    } forEach DZMS_UNITS_MAJOR;
+    } forEach DZMSUnitsMajor;
     
     // rebuild the array for the next mission
-    DZMS_UNITS_MAJOR = [];
+    DZMSUnitsMajor = [];
     
 	//Let's Run the Mission
 	[] execVM format ["\z\addons\dayz_server\DZMS\Missions\Major\%1.sqf",_varName];

--- a/DZMS/Scripts/DZMSMinTimer.sqf
+++ b/DZMS/Scripts/DZMSMinTimer.sqf
@@ -29,9 +29,6 @@ while {_run} do
 	_ranMis = floor (random _cntMis);
 	_varName = DZMSMinorArray select _ranMis;
     
-    // create array of units if it doesn't exist
-    if (isNil "DZMS_UNITS_MINOR") then { DZMS_UNITS_MINOR = []; };
-    
     // clean up all the existing units before starting a new one
     {
         _x enableSimulation false;
@@ -49,10 +46,10 @@ while {_run} do
         deleteVehicle _x;
         deleteGroup (group _x);
         _x = nil;
-    } forEach DZMS_UNITS_MINOR;
+    } forEach DZMSUnitsMinor;
     
     // rebuild the array for the next mission
-    DZMS_UNITS_MINOR = [];
+    DZMSUnitsMinor = [];
     
 	//Let's Run the Mission
 	[] execVM format ["\z\addons\dayz_server\DZMS\Missions\Minor\%1.sqf",_varName];


### PR DESCRIPTION
this should do it.

allows a % to be set in the config

changes DZMSAISpawn function to a call (so it's run on the same thread and units can be properly added to the array)

create waitformissioncomp function which the missions each call to wait for their units to be dead and the player to be in range

unit arrays are handled by a passed name -- this makes it so that any piece of code can create a callback array and then spawn units into it  -- could be handy for future projects where dynamic mission arrays are formed etc.
