### PR TITLE
Check if a player is near (within 500m) before spawning mission

### DIFF
--- a/DZMS/DZMSFunctions.sqf
+++ b/DZMS/DZMSFunctions.sqf
@@ -99,7 +99,7 @@ DZMSFindPos = {
                 if ((_pos distance (_x select 0)) <= (_x select 1)) then {_isBlack = true;};
             } forEach DZMSBlacklistZones;
             
-			_playerNear = {isPlayer _x} count (_pos nearEntities ["CAManBase", 500]) > 1;
+			_playerNear = {isPlayer _x} count (_pos nearEntities ["CAManBase", 500]) > 0;
 			
 			//Lets combine all our checks to possibly end the loop
             if ((_posX != _hardX) AND (_posY != _hardY) AND _noWater AND _okDis AND !_isBlack AND !_playerNear) then {


### PR DESCRIPTION
I've had missions spawn in right beside me. While this can be quite entertaining it is not always desirable. This fix was tested on my server and seems to prevent that.
